### PR TITLE
Fix Client always blocked and timeout'ed

### DIFF
--- a/source/netfilter/client.cpp
+++ b/source/netfilter/client.cpp
@@ -17,6 +17,7 @@ namespace netfilter
 		if( time - last_reset >= manager.GetMaxQueriesWindow( ) )
 		{
 			last_reset = time;
+			count = 1;
 		}
 		else
 		{
@@ -44,6 +45,6 @@ namespace netfilter
 
 	bool Client::TimedOut( uint32_t time ) const
 	{
-		return last_reset - time >= ClientManager::ClientTimeout;
+		return time - last_reset >= ClientManager::ClientTimeout;
 	}
 }


### PR DESCRIPTION
If Client has reached the **GetMaxQueriesWindow** it will always blocked except for the first request in the next window interval.
It looks like the **Client::TimedOut** always returned true, because `last_reset - time` is < 0 and will overflows **uint32_t**.